### PR TITLE
test(domain): add unit tests for domain model 

### DIFF
--- a/src/main/kotlin/racingcar/domain/Cars.kt
+++ b/src/main/kotlin/racingcar/domain/Cars.kt
@@ -17,12 +17,12 @@ data class Cars(
         return Cars(cars.filter { it.position == maxPosition })
     }
 
-    fun forEach(action: (Car) -> Unit) {
-        cars.forEach(action)
+    fun toList(): List<Car> {
+        return cars.map { it.copy() }
     }
 
     fun createRound(index: Int): Round {
-        return Round(index, Cars(cars.map { it.copy() }))
+        return Round(index, Cars(this.toList()))
     }
 
     fun getCarNames(): List<String> {

--- a/src/main/kotlin/racingcar/domain/Round.kt
+++ b/src/main/kotlin/racingcar/domain/Round.kt
@@ -11,7 +11,7 @@ data class Round(val index: Int, val cars: Cars) {
 
     override fun toString(): String {
         return StringBuilder().apply {
-            cars.forEach { car ->
+            cars.toList().forEach { car ->
                 append("${car.name} : ${"-".repeat(car.position)}\n")
             }
         }.toString()

--- a/src/test/kotlin/racingcar/ApplicationTest.kt
+++ b/src/test/kotlin/racingcar/ApplicationTest.kt
@@ -104,9 +104,9 @@ class ApplicationTest : NsTest() {
             run(carNames, roundCount.toString())
 
             val outputText = output()
-            val count = countOccurrences(outputText, "pLose")
-            // roundCount == loserPrintCount
-            assertThat(count).isEqualTo(roundCount)
+            val loserCount = countOccurrences(outputText, "pLose")
+            // roundCount should equal to loserCount
+            assertThat(loserCount).isEqualTo(roundCount)
         },
             first, *rest
         )

--- a/src/test/kotlin/racingcar/unit/CarTest.kt
+++ b/src/test/kotlin/racingcar/unit/CarTest.kt
@@ -28,7 +28,7 @@ class CarTest {
         }
 
         @Test
-        fun `should throw exception if car name has space`() {
+        fun `should throw exception if car name contain space`() {
             val exception = assertThrows<IllegalArgumentException> {
                 Car("po bi")
             }
@@ -48,7 +48,7 @@ class CarTest {
     @DisplayName("moveRandomly()")
     inner class MoveRandomlyTest {
         @Test
-        fun `should move forward if random number greater or equal then 4`() {
+        fun `should move forward if random number greater than or equal to 4`() {
             val car = Car("pobi")
 
             assertRandomNumberInRangeTest({

--- a/src/test/kotlin/racingcar/unit/CarTest.kt
+++ b/src/test/kotlin/racingcar/unit/CarTest.kt
@@ -1,0 +1,74 @@
+package racingcar.unit
+
+import camp.nextstep.edu.missionutils.test.Assertions.assertRandomNumberInRangeTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import racingcar.domain.Car
+
+class CarTest {
+    @Nested
+    @DisplayName("constructor")
+    inner class ConstructorTest {
+        @Test
+        fun `should create a car with a valid name`() {
+            val car = Car("pobi")
+            assertThat(car.name).isEqualTo("pobi")
+            assertThat(car.position).isEqualTo(0)
+        }
+
+        @Test
+        fun `should throw exception if car name is empty`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                Car("")
+            }
+            assertThat(exception.message).isEqualTo("Car name cannot be empty.")
+        }
+
+        @Test
+        fun `should throw exception if car name has space`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                Car("po bi")
+            }
+            assertThat(exception.message).isEqualTo("Car name cannot contain spaces.")
+        }
+
+        @Test
+        fun `should throw exception if car name exceeds 5 characters`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                Car("foobar")
+            }
+            assertThat(exception.message).isEqualTo("Car name cannot exceed 5 characters.")
+        }
+    }
+
+    @Nested
+    @DisplayName("moveRandomly()")
+    inner class MoveRandomlyTest {
+        @Test
+        fun `should move forward if random number greater or equal then 4`() {
+            val car = Car("pobi")
+
+            assertRandomNumberInRangeTest({
+                car.moveRandomly()
+                assertThat(car.position).isEqualTo(1)
+            },
+                4
+            )
+        }
+
+        @Test
+        fun `should not move if random number less than 4`() {
+            val car = Car("pobi")
+
+            assertRandomNumberInRangeTest({
+                car.moveRandomly()
+                assertThat(car.position).isEqualTo(0)
+            },
+                3
+            )
+        }
+    }
+}

--- a/src/test/kotlin/racingcar/unit/CarsTest.kt
+++ b/src/test/kotlin/racingcar/unit/CarsTest.kt
@@ -1,0 +1,90 @@
+package racingcar.unit
+
+import camp.nextstep.edu.missionutils.test.Assertions.assertRandomNumberInRangeTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import racingcar.domain.Car
+import racingcar.domain.Cars
+
+class CarsTest {
+    @Nested
+    @DisplayName("constructor")
+    inner class ConstructorTest {
+
+        @Test
+        fun `should create Cars with unique car names`() {
+            val cars = Cars(listOf(Car("p1"), Car("p2"), Car("p3")))
+            assertThat(cars.getCarNames()).containsExactly("p1", "p2", "p3")
+        }
+
+        @Test
+        fun `should throw exception if car names are duplicated`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                Cars(listOf(Car("p1"), Car("p1")))
+            }
+            assertThat(exception.message).isEqualTo("Car names must be unique.")
+        }
+    }
+
+    @Nested
+    @DisplayName("moveRandomly()")
+    inner class MoveRandomlyTest {
+
+        @Test
+        fun `should move each car if random number is greater than or equal 4`() {
+            val cars = Cars(listOf(Car("p1"), Car("p2")))
+
+            assertRandomNumberInRangeTest({
+                val moved = cars.moveRandomly()
+                assertThat(moved).allMatch { it.position == 1 }
+            }, 4, 5)
+        }
+
+        @Test
+        fun `should not move cars if random number is less than 4`() {
+            val cars = Cars(listOf(Car("p1"), Car("p2")))
+
+            assertRandomNumberInRangeTest({
+                val moved = cars.moveRandomly()
+                assertThat(moved).allMatch { it.position == 0 }
+            }, 1, 2)
+        }
+    }
+
+    @Nested
+    @DisplayName("getMostMovedCar()")
+    inner class GetMostMovedCarTest {
+
+        @Test
+        fun `should return cars with the highest position`() {
+            val cars = Cars(listOf(
+                Car("p1", position = 1),
+                Car("p2", position = 3),
+                Car("p3", position = 3)
+            ))
+            val winners = cars.getMostMovedCar()
+
+            assertThat(winners.getCarNames()).containsExactlyInAnyOrder("p2", "p3")
+        }
+    }
+
+    @Nested
+    @DisplayName("createRound()")
+    inner class CreateRoundTest {
+        @Test
+        fun `should create a round with deep copied cars`() {
+            // given
+            val rawCars = listOf(Car("p1"), Car("p2"))
+            val cars = Cars(rawCars)
+
+            // when
+            val round = cars.createRound(1)
+
+            // then
+            assertThat(round.cars).isNotSameAs(cars)
+        }
+    }
+}

--- a/src/test/kotlin/racingcar/unit/RoundTest.kt
+++ b/src/test/kotlin/racingcar/unit/RoundTest.kt
@@ -1,0 +1,79 @@
+package racingcar.unit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import racingcar.domain.Car
+import racingcar.domain.Cars
+import racingcar.domain.Round
+
+class RoundTest {
+    @Nested
+    @DisplayName("constructor")
+    inner class ConstructorTest {
+
+        @Test
+        fun `should create round with valid index`() {
+            val cars = Cars(listOf(Car("p1"), Car("p2")))
+            val round = Round(1, cars)
+            assertThat(round.index).isEqualTo(1)
+            assertThat(round.cars).isEqualTo(cars)
+        }
+
+        @Test
+        fun `should throw exception if index is zero or less`() {
+            val cars = Cars(listOf(Car("p1")))
+            val exception = assertThrows<IllegalArgumentException> {
+                Round(0, cars)
+            }
+            assertThat(exception.message).isEqualTo("Round index must be a positive number.")
+        }
+    }
+
+    @Nested
+    @DisplayName("winners")
+    inner class WinnersTest {
+
+        @Test
+        fun `should return car with highest position`() {
+            val round = Round(
+                2,
+                Cars(listOf(
+                    Car("p1", position = 1),
+                    Car("p2", position = 3),
+                    Car("p3", position = 3)
+                )))
+
+            val winners = round.winners.getCarNames()
+            assertThat(winners).containsExactlyInAnyOrder("p2", "p3")
+        }
+    }
+
+    @Nested
+    @DisplayName("toString")
+    inner class ToStringTest {
+
+        @Test
+        fun `should return race progress string`() {
+            val cars = Cars(
+                listOf(
+                    Car("p1", position = 2),
+                    Car("p2", position = 0),
+                    Car("p3", position = 3)
+                )
+            )
+            val round = Round(1, cars)
+            val output = round.toString()
+
+            assertThat(output).isEqualTo(
+                """
+                p1 : --
+                p2 : 
+                p3 : ---
+                """.trimIndent() + "\n"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/racingcar/unit/RoundsTest.kt
+++ b/src/test/kotlin/racingcar/unit/RoundsTest.kt
@@ -1,0 +1,55 @@
+package racingcar.unit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import racingcar.domain.Car
+import racingcar.domain.Cars
+import racingcar.domain.Round
+import racingcar.domain.Rounds
+
+class RoundsTest {
+
+    @Nested
+    @DisplayName("getWinners()")
+    inner class GetWinnersTest {
+
+        @Test
+        fun `should return winners from the last round`() {
+            val round1 = Round(1, Cars(listOf(Car("a", 1), Car("b", 2))))
+            val round2 = Round(2, Cars(listOf(Car("a", 3), Car("b", 3), Car("c", 2))))
+
+            val rounds = Rounds(listOf(round1, round2))
+            val winners = rounds.getWinners().getCarNames()
+
+            assertThat(winners).containsExactlyInAnyOrder("a", "b")
+        }
+    }
+
+    @Nested
+    @DisplayName("toString()")
+    inner class ToStringTest {
+
+        @Test
+        fun `should return combined string of all rounds`() {
+            val round1 = Round(1, Cars(listOf(Car("a", 1), Car("b", 2))))
+            val round2 = Round(2, Cars(listOf(Car("a", 3), Car("b", 3))))
+
+            val rounds = Rounds(listOf(round1, round2))
+            val output = rounds.toString()
+
+            assertThat(output).isEqualTo(
+                """
+                a : -
+                b : --
+                
+                a : ---
+                b : ---
+                
+                
+                """.trimIndent()
+            )
+        }
+    }
+}


### PR DESCRIPTION
# 📜 Summary

This PR adds unit tests for domain models(`Car`, `Cars`, `Round`, `Rounds`).
It also refactors the `Cars` class by removing `forEach()` and introducing a `toList()` method that returns a deep-copied car list. 

# 🧪 Test Verification
All tests pass successfully:
```bash
./gradlew clean test
```